### PR TITLE
fix: only execute mfe-related tasks when mfe plugin is enabled

### DIFF
--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------
 
 # MFE-specific settings
-{% if get_mfe("course-authoring") %}
+{% if 'get_mfe' in vars() and get_mfe("course-authoring") %}
 COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
 {% endif %}
 

--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -8,10 +8,12 @@
 #------------------------------------------------------------------------------
 
 # MFE-specific settings
-{% if get_mfe is defined and get_mfe("course-authoring") %}
-COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
-{% endif %}
+{% if get_mfe is defined %}
+    {% if get_mfe("course-authoring") %}
+        COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
+    {% endif %}
 
-LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
-CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
-CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+    LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+    CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
+    CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+{% endif %}

--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -9,11 +9,11 @@
 
 # MFE-specific settings
 {% if get_mfe is defined %}
-    {% if get_mfe("course-authoring") %}
-        COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
-    {% endif %}
+{% if get_mfe("course-authoring") %}
+COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
+{% endif %}
 
-    LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
-    CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
-    CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
 {% endif %}

--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -8,10 +8,8 @@
 #------------------------------------------------------------------------------
 
 # MFE-specific settings
-{% if get_mfe %}
-    {% if get_mfe("course-authoring") %}
-    COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
-    {% endif %}
+{% if get_mfe is defined and get_mfe("course-authoring") %}
+COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
 {% endif %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")

--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -8,7 +8,7 @@
 #------------------------------------------------------------------------------
 
 # MFE-specific settings
-{% if 'get_mfe' in vars() and get_mfe("course-authoring") %}
+{% if get_mfe and get_mfe("course-authoring") %}
 COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
 {% endif %}
 

--- a/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-cms-production-settings
@@ -8,8 +8,10 @@
 #------------------------------------------------------------------------------
 
 # MFE-specific settings
-{% if get_mfe and get_mfe("course-authoring") %}
-COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
+{% if get_mfe %}
+    {% if get_mfe("course-authoring") %}
+    COURSE_AUTHORING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/course-authoring"
+    {% endif %}
 {% endif %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")

--- a/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
@@ -17,7 +17,7 @@ ENABLE_MFE_CONFIG_API = True
 MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
-{% if 'get_mfe' in vars() %}
+{% if get_mfe %}
   {% if get_mfe("authn") %}
   FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
   {% endif %}

--- a/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
@@ -17,11 +17,13 @@ ENABLE_MFE_CONFIG_API = True
 MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
-{% if get_mfe("authn") %}
-FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
-{% endif %}
-{% if get_mfe("communications") %}
-FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True
+{% if 'get_mfe' in vars() %}
+  {% if get_mfe("authn") %}
+  FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
+  {% endif %}
+  {% if get_mfe("communications") %}
+  FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True
+  {% endif %}
 {% endif %}
 
 # SCORM SETTINGS

--- a/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
@@ -12,18 +12,18 @@
 
 # MFE-specific settings
 {% if get_mfe is defined %}
-  # MFE: enable API and set a low cache timeout for the settings. otherwise, weird
-  # configuration bugs occur. Also, the view is not costly at all, and it's also cached on
-  # the frontend. (5 minutes, hardcoded)
-  ENABLE_MFE_CONFIG_API = True
-  MFE_CONFIG_API_CACHE_TIMEOUT = 1
+# MFE: enable API and set a low cache timeout for the settings. otherwise, weird
+# configuration bugs occur. Also, the view is not costly at all, and it's also cached on
+# the frontend. (5 minutes, hardcoded)
+ENABLE_MFE_CONFIG_API = True
+MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
-  {% if get_mfe("authn") %}
-  FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
-  {% endif %}
-  {% if get_mfe("communications") %}
-  FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True
-  {% endif %}
+{% if get_mfe("authn") %}
+FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
+{% endif %}
+{% if get_mfe("communications") %}
+FEATURES['ENABLE_NEW_BULK_EMAIL_EXPERIENCE'] = True
+{% endif %}
 {% endif %}
 
 # SCORM SETTINGS

--- a/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
@@ -9,15 +9,15 @@
 #------------------------------------------------------------------------------
 
 # copied from: https://github.com/overhangio/tutor-mfe/blob/master/tutormfe/patches/openedx-common-settings
-#
-# MFE: enable API and set a low cache timeout for the settings. otherwise, weird
-# configuration bugs occur. Also, the view is not costly at all, and it's also cached on
-# the frontend. (5 minutes, hardcoded)
-ENABLE_MFE_CONFIG_API = True
-MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
 {% if get_mfe is defined %}
+  # MFE: enable API and set a low cache timeout for the settings. otherwise, weird
+  # configuration bugs occur. Also, the view is not costly at all, and it's also cached on
+  # the frontend. (5 minutes, hardcoded)
+  ENABLE_MFE_CONFIG_API = True
+  MFE_CONFIG_API_CACHE_TIMEOUT = 1
+
   {% if get_mfe("authn") %}
   FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
   {% endif %}

--- a/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-common-settings
@@ -17,7 +17,7 @@ ENABLE_MFE_CONFIG_API = True
 MFE_CONFIG_API_CACHE_TIMEOUT = 1
 
 # MFE-specific settings
-{% if get_mfe %}
+{% if get_mfe is defined %}
   {% if get_mfe("authn") %}
   FEATURES['ENABLE_AUTHN_MICROFRONTEND'] = True
   {% endif %}

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -32,55 +32,56 @@ MFE_CONFIG["USER_INFO_COOKIE_NAME"] = "user-info"
 MFE_CONFIG["ACCESS_TOKEN_COOKIE_NAME"] = "edx-jwt-cookie-header-payload"
 
 # MFE-specific settings
+{% if 'get_mfe' in vars() %}
+    {% if get_mfe("authn") %}
+    AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
+    AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
+    MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
+    {% endif %}
 
-{% if get_mfe("authn") %}
-AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
-AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
-MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
-{% endif %}
+    {% if get_mfe("account") %}
+    ACCOUNT_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/account"
+    MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
+    {% endif %}
 
-{% if get_mfe("account") %}
-ACCOUNT_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/account"
-MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
-{% endif %}
+    {% if get_mfe("course-authoring") %}
+    MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
+    MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
+    MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "https://{{ MFE_HOST }}/course-authoring"
+    {% endif %}
 
-{% if get_mfe("course-authoring") %}
-MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
-MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
-MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "https://{{ MFE_HOST }}/course-authoring"
-{% endif %}
+    {% if get_mfe("discussions") %}
+    DISCUSSIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/discussions"
+    MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
+    DISCUSSIONS_MFE_FEEDBACK_URL = None
+    {% endif %}
 
-{% if get_mfe("discussions") %}
-DISCUSSIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/discussions"
-MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
-DISCUSSIONS_MFE_FEEDBACK_URL = None
-{% endif %}
+    {% if get_mfe("gradebook") %}
+    WRITABLE_GRADEBOOK_URL = "https://{{ MFE_HOST }}/gradebook"
+    {% endif %}
 
-{% if get_mfe("gradebook") %}
-WRITABLE_GRADEBOOK_URL = "https://{{ MFE_HOST }}/gradebook"
-{% endif %}
+    {% if get_mfe("learner-dashboard") %}
+    LEARNER_HOME_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learner-dashboard/"
+    {% endif %}
 
-{% if get_mfe("learner-dashboard") %}
-LEARNER_HOME_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learner-dashboard/"
-{% endif %}
+    {% if get_mfe("learning") %}
+    LEARNING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learning"
+    MFE_CONFIG["LEARNING_BASE_URL"] = "https://{{ MFE_HOST }}/learning"
+    {% endif %}
 
-{% if get_mfe("learning") %}
-LEARNING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learning"
-MFE_CONFIG["LEARNING_BASE_URL"] = "https://{{ MFE_HOST }}/learning"
-{% endif %}
+    {% if get_mfe("ora-grading") %}
+    ORA_GRADING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/ora-grading"
+    {% endif %}
 
-{% if get_mfe("ora-grading") %}
-ORA_GRADING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/ora-grading"
-{% endif %}
+    {% if get_mfe("profile") %}
+    PROFILE_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/profile/u/"
+    MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "https://{{ MFE_HOST }}/profile"
+    {% endif %}
 
-{% if get_mfe("profile") %}
-PROFILE_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/profile/u/"
-MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "https://{{ MFE_HOST }}/profile"
-{% endif %}
-
-{% if get_mfe("communications") %}
-COMMUNICATIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/communications"
-MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
+    {% if get_mfe("communications") %}
+    COMMUNICATIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/communications"
+    MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
+    {% endif %}
 {% endif %}
 
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -10,7 +10,8 @@
 #------------------------------------------------------------------------------
 # Dynamic config API settings
 # https://openedx.github.io/frontend-platform/module-Config.html
-MFE_CONFIG["BASE_URL"] = "{{ MFE_HOST }}"
+{% if get_mfe is defined %}
+MFE_CONFIG["BASE_URL"] = "{{ MFE_HOST }}"l
 MFE_CONFIG["CSRF_TOKEN_API_PATH"] = "/csrf/api/v1/token"
 MFE_CONFIG["CREDENTIALS_BASE_URL"] = ""
 MFE_CONFIG["DISCOVERY_API_BASE_URL"] = "{% if DISCOVERY_HOST is defined %}https://{{ DISCOVERY_HOST }}{% endif %}"
@@ -31,61 +32,61 @@ MFE_CONFIG["STUDIO_BASE_URL"] = "https://{{ CMS_HOST }}"
 MFE_CONFIG["USER_INFO_COOKIE_NAME"] = "user-info"
 MFE_CONFIG["ACCESS_TOKEN_COOKIE_NAME"] = "edx-jwt-cookie-header-payload"
 
-# MFE-specific settings
-{% if get_mfe is defined %}
-    {% if get_mfe("authn") %}
-    AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
-    AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
-    MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
-    {% endif %}
+# MFE-specific settingss
 
-    {% if get_mfe("account") %}
-    ACCOUNT_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/account"
-    MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
-    {% endif %}
+{% if get_mfe("authn") %}
+AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
+AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"
+MFE_CONFIG["DISABLE_ENTERPRISE_LOGIN"] = True
+{% endif %}
 
-    {% if get_mfe("course-authoring") %}
-    MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
-    MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
-    MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "https://{{ MFE_HOST }}/course-authoring"
-    {% endif %}
+{% if get_mfe("account") %}
+ACCOUNT_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/account"
+MFE_CONFIG["ACCOUNT_SETTINGS_URL"] = ACCOUNT_MICROFRONTEND_URL
+{% endif %}
 
-    {% if get_mfe("discussions") %}
-    DISCUSSIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/discussions"
-    MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
-    DISCUSSIONS_MFE_FEEDBACK_URL = None
-    {% endif %}
+{% if get_mfe("course-authoring") %}
+MFE_CONFIG["ENABLE_NEW_EDITOR_PAGES"] = True
+MFE_CONFIG["ENABLE_PROGRESS_GRAPH_SETTINGS"] = True
+MFE_CONFIG["COURSE_AUTHORING_MICROFRONTEND_URL"] = "https://{{ MFE_HOST }}/course-authoring"
+{% endif %}
 
-    {% if get_mfe("gradebook") %}
-    WRITABLE_GRADEBOOK_URL = "https://{{ MFE_HOST }}/gradebook"
-    {% endif %}
+{% if get_mfe("discussions") %}
+DISCUSSIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/discussions"
+MFE_CONFIG["DISCUSSIONS_MFE_BASE_URL"] = DISCUSSIONS_MICROFRONTEND_URL
+DISCUSSIONS_MFE_FEEDBACK_URL = None
+{% endif %}
 
-    {% if get_mfe("learner-dashboard") %}
-    LEARNER_HOME_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learner-dashboard/"
-    {% endif %}
+{% if get_mfe("gradebook") %}
+WRITABLE_GRADEBOOK_URL = "https://{{ MFE_HOST }}/gradebook"
+{% endif %}
 
-    {% if get_mfe("learning") %}
-    LEARNING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learning"
-    MFE_CONFIG["LEARNING_BASE_URL"] = "https://{{ MFE_HOST }}/learning"
-    {% endif %}
+{% if get_mfe("learner-dashboard") %}
+LEARNER_HOME_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learner-dashboard/"
+{% endif %}
 
-    {% if get_mfe("ora-grading") %}
-    ORA_GRADING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/ora-grading"
-    {% endif %}
+{% if get_mfe("learning") %}
+LEARNING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/learning"
+MFE_CONFIG["LEARNING_BASE_URL"] = "https://{{ MFE_HOST }}/learning"
+{% endif %}
 
-    {% if get_mfe("profile") %}
-    PROFILE_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/profile/u/"
-    MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "https://{{ MFE_HOST }}/profile"
-    {% endif %}
+{% if get_mfe("ora-grading") %}
+ORA_GRADING_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/ora-grading"
+{% endif %}
 
-    {% if get_mfe("communications") %}
-    COMMUNICATIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/communications"
-    MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
-    {% endif %}
+{% if get_mfe("profile") %}
+PROFILE_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/profile/u/"
+MFE_CONFIG["ACCOUNT_PROFILE_URL"] = "https://{{ MFE_HOST }}/profile"
+{% endif %}
 
-    LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
-    CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
-    CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+{% if get_mfe("communications") %}
+COMMUNICATIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/communications"
+MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
+{% endif %}
+
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
 {% endif %}
 
 # CORS and CSRF settings for CDN

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -32,7 +32,7 @@ MFE_CONFIG["USER_INFO_COOKIE_NAME"] = "user-info"
 MFE_CONFIG["ACCESS_TOKEN_COOKIE_NAME"] = "edx-jwt-cookie-header-payload"
 
 # MFE-specific settings
-{% if 'get_mfe' in vars() %}
+{% if get_mfe %}
     {% if get_mfe("authn") %}
     AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
     AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -82,11 +82,11 @@ MFE_CONFIG["ACCESS_TOKEN_COOKIE_NAME"] = "edx-jwt-cookie-header-payload"
     COMMUNICATIONS_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/communications"
     MFE_CONFIG["SCHEDULE_EMAIL_SECTION"] = True
     {% endif %}
-{% endif %}
 
-LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
-CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
-CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+    LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+    CORS_ORIGIN_WHITELIST.append("https://{{ MFE_HOST }}")
+    CSRF_TRUSTED_ORIGINS.append("https://{{ MFE_HOST }}")
+{% endif %}
 
 # CORS and CSRF settings for CDN
 CORS_ORIGIN_WHITELIST.append("https://cdn.{{ LMS_HOST }}")

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -11,7 +11,7 @@
 # Dynamic config API settings
 # https://openedx.github.io/frontend-platform/module-Config.html
 {% if get_mfe is defined %}
-MFE_CONFIG["BASE_URL"] = "{{ MFE_HOST }}"l
+MFE_CONFIG["BASE_URL"] = "{{ MFE_HOST }}"
 MFE_CONFIG["CSRF_TOKEN_API_PATH"] = "/csrf/api/v1/token"
 MFE_CONFIG["CREDENTIALS_BASE_URL"] = ""
 MFE_CONFIG["DISCOVERY_API_BASE_URL"] = "{% if DISCOVERY_HOST is defined %}https://{{ DISCOVERY_HOST }}{% endif %}"

--- a/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
+++ b/tutork8s_deploy_tasks/patches/openedx-lms-production-settings
@@ -32,7 +32,7 @@ MFE_CONFIG["USER_INFO_COOKIE_NAME"] = "user-info"
 MFE_CONFIG["ACCESS_TOKEN_COOKIE_NAME"] = "edx-jwt-cookie-header-payload"
 
 # MFE-specific settings
-{% if get_mfe %}
+{% if get_mfe is defined %}
     {% if get_mfe("authn") %}
     AUTHN_MICROFRONTEND_URL = "https://{{ MFE_HOST }}/authn"
     AUTHN_MICROFRONTEND_DOMAIN  = "{{ MFE_HOST }}/authn"


### PR DESCRIPTION
# fix: only execute mfe-related tasks when mfe plugin is enabled

## Type of Change

<!-- What type of change does your code introduce? -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Resolves

- Allows use of deployment tasks when MFE plugin is not enabled

## Changes

- Within patch templates, wrap any logic that requires MFE plugin context in conditionals that check whether that context exists.

## Testing

- Run deployment with MFE plugin enabled & disabled, confirm both scenarios are successful.

## Screenshots

- N/A

## Dependencies

- N/A

## Breaking Changes

- No breaking changes.
